### PR TITLE
Remove text-encoding polyfill

### DIFF
--- a/packages/hashicon/package.json
+++ b/packages/hashicon/package.json
@@ -52,15 +52,13 @@
   },
   "dependencies": {
     "@stablelib/blake2s": "^1.0.0",
-    "js-sha3": "^0.8.0",
-    "text-encoding": "^0.7.0"
+    "js-sha3": "^0.8.0"
   },
   "devDependencies": {
     "typescript": "^3.9.6",
     "rimraf": "^2.6.3",
     "jest": "24.8.0",
     "@types/jest": "24.0.13",
-    "@types/text-encoding": "0.0.35",
     "ts-jest": "24.0.2",
     "jest-serial-runner": "1.1.0",
     "@storybook/html": "^5.3.19",

--- a/packages/hashicon/src/index.ts
+++ b/packages/hashicon/src/index.ts
@@ -3,7 +3,6 @@ import {Params, DefaultParams} from './params';
 import {deepMerge} from './utils';
 import {keccak256} from 'js-sha3';
 import {BLAKE2s} from '@stablelib/blake2s';
-import {TextEncoder} from 'text-encoding';
 
 export {Params, HasherType} from './params';
 


### PR DESCRIPTION
Closes #34

This is no longer needed and was just a polyfill, which is also now deprecated, node and browsers have good support for it out of the box.